### PR TITLE
Replace `getinfo` rpc calls with `getnetworkinfo` and `getblockchaininfo`

### DIFF
--- a/src/dashd_intf.py
+++ b/src/dashd_intf.py
@@ -915,9 +915,9 @@ class DashdInterface(WndUtils):
     @control_rpc_call
     def getinfo(self, verify_node: bool = True):
         if self.open():
-            info = self.proxy.getinfo()
+            info = self.proxy.getblockchaininfo()
             if verify_node:
-                node_under_testnet = info.get('testnet')
+                node_under_testnet = (info.get('chain') == 'test')
                 if self.app_config.is_testnet() and not node_under_testnet:
                     raise Exception('This RPC node works under Dash MAINNET, but your current configuration is '
                                     'for TESTNET.')

--- a/src/proposals_dlg.py
+++ b/src/proposals_dlg.py
@@ -1606,7 +1606,7 @@ class ProposalsDlg(QDialog, ui_proposals.Ui_ProposalsDlg, wnd_utils.WndUtils):
                         db_oper_duration = 0.0
                         db_oper_count = 0
                         network_duration = 0.0
-                        node_info = self.dashd_intf.rpc_call(False, False, 'getinfo')
+                        node_info = self.dashd_intf.rpc_call(False, False, 'getnetworkinfo')
                         if node_info.get('version', 140000) < 140000:
                             getvotes_fun_name = 'getvotes'
                         else:


### PR DESCRIPTION
This is required to be compatible with Dash Core v0.16 RPC changes.