### PR TITLE
chore: remove sentinel which is not needed since Dash Core v20

### DIFF
--- a/ansible/install-dash-node/install-dash-node-ubuntu.yml
+++ b/ansible/install-dash-node/install-dash-node-ubuntu.yml
@@ -345,32 +345,6 @@
       when: enable_dashd_indexing
 
     - block:
-      - name: Clone sentinel repository
-        git:
-          repo: https://github.com/dashpay/sentinel.git
-          dest: ~/.dashcore/sentinel
-        become_user: "{{ dashuser }}"
-
-      - name: Check whether sentinel venv exists
-        stat:
-          path: ~/.dashcore/sentinel/venv
-        register: sentinel_venv_exists
-        become_user: "{{ dashuser }}"
-
-      - name: Create sentinel runtime environment
-        shell:
-          cmd: |
-            cd ~/.dashcore/sentinel && virtualenv venv && venv/bin/pip install -r requirements.txt && venv/bin/py.test test && venv/bin/python bin/sentinel.py
-        when: not sentinel_venv_exists.stat.exists
-        become_user: "{{ dashuser }}"
-
-      - name: Create crontab entry for sentinel
-        cron:
-          job: "cd ~/.dashcore/sentinel && ./venv/bin/python bin/sentinel.py 2>&1 >> sentinel-cron.log"
-          name: "Sentinel execution"
-        become_user: "{{ dashuser }}"
-      when: is_masternode
-
     - name: Create a systemd service for dashd
       template:
         src: files/dashd-service.j2

--- a/doc/installing-dash-node-manual.md
+++ b/doc/installing-dash-node-manual.md
@@ -259,42 +259,7 @@ If it doesn't happen, open the following address in your web browser: https://gi
 
   What values you choose for USERNAME_FOR_RPC_INTERFACE and PASSWORD_FOR_RPC_INTERFACE is completely irrelevant.
 
-### 12. Installing *sentinel*
-Sentinel is an additional program that must be installed for the masternode to perform all necessary operations. It is a program written in Python and its installation basically consists of downloading the source code from GitHub and preparing the runtime environment.
-
-The next steps will be performed from the SSH terminal after logging in to the dash user.
-
-* Download the sentinel source code and create the runtime environment:
-  ```
-  cd ~/.dashcore
-  git clone https://github.com/dashpay/sentinel
-  cd sentinel
-  virtualenv venv
-  venv/bin/pip install -r requirements.txt
-  venv/bin/py.test test 
-  venv/bin/python bin/sentinel.py
-  ```
-
-  If your node is not completely synchronized with the network, you will see the appropriate message. If everything is ok, the last command will return nothing.
-
-* Configure sentinel execution
-
-  Sentinel is a script that needs to be run periodically (once per minute) so now you need to add a proper cron job.
-  
-  Run the cron configuration editor:
-  ```
-  crontab -e
-  ```
-  > **Note**. If this is the first time you are running crontab, you will be asked which editor to use for this. If you are not an advanced Linux user I suggest you choose the nano editor.
-  
-  Add the following line:
-  ```
-  * * * * * cd ~/.dashcore/sentinel && ./venv/bin/python bin/sentinel.py 2>&1 >> sentinel-cron.log
-  ```
-
-* Save your changes (CTRL+O, ENTER) and exit the editor (CTRL+X)
-
-### 13. Start the dashd program and wait for the blockchain synchronization to complete
+### 12. Start the dashd program and wait for the blockchain synchronization to complete
 ```
 ~/.dashcore/dashd
 ```

--- a/src/dash_utils.py
+++ b/src/dash_utils.py
@@ -29,7 +29,6 @@ OP_EQUALVERIFY = b'\x88'
 OP_CHECKSIG = b'\xAC'
 OP_EQUAL = b'\x87'
 
-DEFAULT_SENTINEL_VERSION = 0x010001  # sentinel version before implementation of nSentinelVersion in CMasternodePing
 DEFAULT_DAEMON_VERSION = 120200  # daemon version before implementation of nDaemonVersion in CMasternodePing
 MASTERNODE_TX_MINIMUM_CONFIRMATIONS = 15
 DASH_PLATFORM_DEFAULT_P2P_PORT = 26656


### PR DESCRIPTION
Since Dash Core v20 no more sentinel is needed:
 - https://www.dash.org/blog/dashcore-v20-0-product-brief/
 - https://github.com/dashpay/dash/blob/v20.0.0/doc/release-notes.md#sentinel-deprecation