### PR TITLE
fix: Qt fatal "QThread: Destroyed while thread is still running" on exit

### DIFF
--- a/app-params.json
+++ b/app-params.json
@@ -1,13 +1,13 @@
 {
-  "appCurrentVersion": "0.9.40",
+  "appCurrentVersion": "0.9.41",
   "exeDownloads": {
-    "mac": "https://github.com/Bertrand256/dash-masternode-tool/releases/download/v0.9.40/DashMasternodeTool_0.9.40.mac.dmg",
-    "win64": "https://github.com/Bertrand256/dash-masternode-tool/releases/download/v0.9.40/DashMasternodeTool_0.9.40.win64.zip",
-    "linux": "https://github.com/Bertrand256/dash-masternode-tool/releases/download/v0.9.40/DashMasternodeTool_0.9.40.linux.tar.gz"
+    "mac": "https://github.com/Bertrand256/dash-masternode-tool/releases/download/v0.9.41/DashMasternodeTool_0.9.41.mac-x64.dmg",
+    "win64": "https://github.com/Bertrand256/dash-masternode-tool/releases/download/v0.9.41/DashMasternodeTool_0.9.41.win64.zip",
+    "linux": "https://github.com/Bertrand256/dash-masternode-tool/releases/download/v0.9.41/DashMasternodeTool_0.9.41.linux.tar.gz"
   },
   "defaultDashdProtocol": {
-    "mainnet": 70233,
-    "testnet": 70233
+    "mainnet": 70238,
+    "testnet": 70238
   },
   "sporks": [
     {

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,15 @@
+## [0.9.41] - 2026-04-08
+### New
+- Added the option to hide “dust” UTXOs in the wallet window.
+- Added binaries for macOS (Apple Silicon) and Linux (AppImage).
+- Added automated builds via GitHub Actions.
+
+### Fixed
+- Fixed the “XXXX function is not supported by the RPC node you are connected to” error when using a custom RPC node.
+- Fixed the “DMTENCRYPTEDV1” error that could occur during `protx` calls when a connection issue happened (e.g., a timeout).
+- Optimized address balance fetching by batching requests, reducing redundant API calls.
+- Wallet: the "tree_id is empty" error when the "Masternode Address" view is active.
+
 ## [0.9.40] - 2025-03-18
 **Fixed**
 - "Incorrect number of bindings supplied" error in the wallet dialog

--- a/release-notes.md
+++ b/release-notes.md
@@ -7,3 +7,4 @@
 - Fixed the “XXXX function is not supported by the RPC node you are connected to” error when using a custom RPC node.
 - Fixed the “DMTENCRYPTEDV1” error that could occur during `protx` calls when a connection issue happened (e.g., a timeout).
 - Optimized address balance fetching by batching requests, reducing redundant API calls.
+- Wallet: the "tree_id is empty" error when the "Masternode Address" view is active.

--- a/src/app_main_view_wdg.py
+++ b/src/app_main_view_wdg.py
@@ -302,12 +302,20 @@ class WdgAppMainView(QWidget, QDetectThemeChange, ui_app_main_view_wdg.Ui_WdgApp
 
     def stop_threads(self):
         self.finishing = True
+        # Wait for workers while pumping the event loop - otherwise a worker
+        # currently blocked inside call_in_main_thread will deadlock against
+        # the main thread that is now waiting on it.
         if self.refresh_status_thread_ref:
             log.info('Waiting for refresh_status_thread to finish...')
-            self.refresh_status_thread_ref.wait(5000)
         if self.refresh_price_thread_ref:
             log.info('Waiting for refresh_price_thread to finish...')
-            self.refresh_price_thread_ref.wait(5000)
+        if self.refresh_net_mnasternodes_thred_ref:
+            log.info('Waiting for refresh_net_mnasternodes_thred to finish...')
+        WndUtils.wait_for_threads(
+            [self.refresh_status_thread_ref,
+             self.refresh_price_thread_ref,
+             self.refresh_net_mnasternodes_thred_ref],
+            5000)
 
     def resume_threads(self):
         self.finishing = False

--- a/src/bip44_wallet.py
+++ b/src/bip44_wallet.py
@@ -931,7 +931,8 @@ class Bip44Wallet(QObject):
                                 a.last_balance_verify_ts = int(time.time())
                                 if current_balance is not None and current_balance != a.balance:
                                     log.warning(f'Balance of address {a.address}, id: {a.id} discrepency; cached '
-                                                f'balance: {a.balance}, network balance: {current_balance}')
+                                                f'balance: {a.balance} ({app_utils.to_string(a.balance / 1e8)} Dash), '
+                                                f'network balance: {current_balance} ({app_utils.to_string(current_balance / 1e8)} Dash)')
 
                                     txes = self.dashd_intf.getaddressdeltasrawtx_dmt(addresses=[a.address], start = 0,
                                                                                      end = max_block_height, verbose=1,
@@ -965,7 +966,7 @@ class Bip44Wallet(QObject):
     def _process_transaction(self, db_cursor, tx_hash: str, tx_json: Dict = None, skip_cache=False) \
             -> Tuple[int, Optional[Dict]]:
         """
-        Adds records related to transaction do a local cache database, fetching a transaction detaisl (JSON) from RPC
+        Adds records related to transaction do a local cache database, fetching a transaction details (JSON) from RPC
         node if necessary.
         :param db_cursor: cursor to a local database
         :param tx_hash: hash of the transaction
@@ -979,10 +980,6 @@ class Bip44Wallet(QObject):
         try:
             if not tx_json:
                 tx_json = self._getrawtransaction(tx_hash, skip_cache=skip_cache)
-
-            if not self.__tree_id:
-                log.error('Bip44Wallet error: tree_id is empty')
-                raise Exception('Bip44Wallet error: tree_id is empty')
 
             db_cursor.execute('select id, block_height from tx where tx_hash=?', (tx_hash, ))
             row = db_cursor.fetchone()
@@ -1647,16 +1644,22 @@ class Bip44Wallet(QObject):
         diff = time.time() - tm_begin
         log.debug('list_utxos_for_account exec time: %ss', diff)
 
-    def list_utxos_for_addresses(self, address_ids: List[int], only_new = False,
-                                 filter_by_satoshis: Optional[int] = None) -> Generator[UtxoType, None, None]:
+    def list_utxos_for_addresses(
+            self, address_ids: List[int],
+            only_new = False,
+            filter_by_satoshis: Optional[int] = None,
+            skip_hw: bool = False
+    ) -> Generator[UtxoType, None, None]:
         db_cursor = self.db_intf.get_cursor()
         try:
             params = []
             sql_text = "select o.id, tx.block_height, tx.coinbase,tx.block_timestamp, tx.tx_hash, o.output_index, " \
                        "o.satoshis, a.id from tx_output o join address a" \
                        " on a.address=o.address join tx on tx.id=o.tx_id where (spent_tx_hash is null " \
-                       " or spent_input_index is null) and a.id in (select id from temp_ids2) and a.tree_id=?"
-            params.append(self.__tree_id)
+                       " or spent_input_index is null) and a.id in (select id from temp_ids2)"
+            if not skip_hw:
+                sql_text += " and a.tree_id=?"
+                params.append(self.__tree_id)
 
             self._fill_temp_ids_table(address_ids, db_cursor, tab_sufix='2')
 
@@ -1712,7 +1715,13 @@ class Bip44Wallet(QObject):
                 self.db_intf.commit()
             self.db_intf.release_cursor()
 
-    def _prepare_cursor_for_txs_list(self, db_cursor, account_id: Optional[int], address_ids: Optional[List[int]]):
+    def _prepare_cursor_for_txs_list(
+            self,
+            db_cursor,
+            account_id: Optional[int],
+            address_ids: Optional[List[int]],
+            skip_hw: bool = False
+    ):
 
         cond_params = []
         if account_id is not None:
@@ -1738,12 +1747,19 @@ class Bip44Wallet(QObject):
                    t.block_timestamp,
                    0 is_coinbase,
                    -1
-            from tx_input i join tx t on t.id=i.tx_id join address a on a.address=i.src_address and a.tree_id=?"""
+            from tx_input i join tx t on t.id=i.tx_id join address a on a.address=i.src_address"""
 
-        params.append(self.__tree_id)
+        if not skip_hw:
+            sql_text += ' and a.tree_id=?'
+            params.append(self.__tree_id)
+            hw_cond1 = ' and a.tree_id=?'
+            hw_cond2 = ' and ai.tree_id=?'
+        else:
+            hw_cond1 = ''
+            hw_cond2 = ''
         params.extend(cond_params)
 
-        sql_text += condition + """ group by t.id
+        sql_text += condition + f""" group by t.id
             union
             select 1 type,
                    group_concat(DISTINCT ifnull(ai.id,'')||':'||ai.address),
@@ -1754,11 +1770,12 @@ class Bip44Wallet(QObject):
                    t.block_height,
                    t.block_timestamp, max(i.coinbase) is_coinbase,
                    o.id
-            from tx_output o join tx t on t.id=o.tx_id join address a on a.address=o.address and a.tree_id=?
-            join tx_input i on i.tx_id=t.id left join address ai on ai.address=i.src_address and ai.tree_id=?"""
+            from tx_output o join tx t on t.id=o.tx_id join address a on a.address=o.address { hw_cond1 }
+            join tx_input i on i.tx_id=t.id left join address ai on ai.address=i.src_address { hw_cond2 }"""
 
-        params.append(self.__tree_id)
-        params.append(self.__tree_id)
+        if not skip_hw:
+            params.append(self.__tree_id)
+            params.append(self.__tree_id)
         params.extend(cond_params)
 
         sql_text += condition + """ group by o.id
@@ -1786,15 +1803,20 @@ class Bip44Wallet(QObject):
                 else:
                     yield addr_str
 
-    def list_txs(self, account_id: Optional[int], address_ids: Optional[List[int]], only_new = False) -> \
-            Generator[TxType, None, None]:
+    def list_txs(
+            self,
+            account_id: Optional[int],
+            address_ids: Optional[List[int]],
+            only_new = False,
+            skip_hw: bool = False
+    ) -> Generator[TxType, None, None]:
 
         tm_begin = time.time()
         if account_id:
             self.validate_hd_tree()  # we don't need a hw connection when scanning specific addresses
         db_cursor = self.db_intf.get_cursor()
         try:
-            self._prepare_cursor_for_txs_list(db_cursor, account_id, address_ids)
+            self._prepare_cursor_for_txs_list(db_cursor, account_id, address_ids, skip_hw)
 
             for type, snd_addrs, rcp_addrs, satoshis, tx_id, tx_hash, bh, bts, is_coinbase, output_id \
                     in db_cursor.fetchall():

--- a/src/dash_masternode_tool.py
+++ b/src/dash_masternode_tool.py
@@ -66,6 +66,12 @@ if __name__ == '__main__':
     except Exception:
         pass
 
+    # Ensure any running WorkerThread is cooperatively stopped before sip
+    # tears down the Qt object tree at interpreter finalization. Without
+    # this, a worker still running at exit causes Qt to fatal-abort with
+    # "QThread: Destroyed while thread is still running".
+    app.aboutToQuit.connect(WndUtils.stop_all_threads)
+
     ui = main_dlg.MainWindow(app_dir, ui_dark_mode_activated)
     ui.show()
 

--- a/src/wallet_dlg.py
+++ b/src/wallet_dlg.py
@@ -494,10 +494,12 @@ class WalletDlg(QDialog, ui_wallet_dlg.Ui_WalletDlg, WndUtils):
         self.finishing = True
         self.data_thread_event.set()
         self.display_thread_event.set()
-        if self.data_thread_ref:
-            self.data_thread_ref.wait(5000)
-        if self.display_thread_ref:
-            self.display_thread_ref.wait(5000)
+        # Wait for workers while pumping the event loop - otherwise a worker
+        # currently blocked inside call_in_main_thread will deadlock against
+        # the main thread that is now waiting on it.
+        WndUtils.wait_for_threads(
+            [self.data_thread_ref, self.display_thread_ref, self.update_data_view_thread_ref],
+            5000)
 
     def start_threads(self):
         self.finishing = False

--- a/src/wallet_dlg.py
+++ b/src/wallet_dlg.py
@@ -1344,7 +1344,7 @@ class WalletDlg(QDialog, ui_wallet_dlg.Ui_WalletDlg, WndUtils):
             for mni in self.selected_mns:
                 if mni.address and not mni.address.id in address_ids:
                     address_ids.append(mni.address.id)
-            list_utxos = self.bip44_wallet.list_utxos_for_addresses(address_ids)
+            list_utxos = self.bip44_wallet.list_utxos_for_addresses(address_ids, skip_hw=True)
         else:
             raise Exception('Invalid utxo_src_mode')
         return list_utxos
@@ -1364,7 +1364,7 @@ class WalletDlg(QDialog, ui_wallet_dlg.Ui_WalletDlg, WndUtils):
             for mni in self.selected_mns:
                 if mni.address and not mni.address.id in address_ids:
                     address_ids.append(mni.address.id)
-            list_txs = self.bip44_wallet.list_txs(None, address_ids, only_new)
+            list_txs = self.bip44_wallet.list_txs(None, address_ids, only_new, skip_hw=True)
         else:
             raise Exception('Invalid utxo_src_mode')
         return list_txs

--- a/src/wnd_utils.py
+++ b/src/wnd_utils.py
@@ -18,7 +18,7 @@ import thread_utils
 import time
 from PyQt5 import QtWidgets, QtCore, QtGui
 from PyQt5.QtCore import Qt, QObject, QLocale, QEventLoop, QTimer, QPoint, QEvent, QPointF, QSize, QModelIndex, QRect, \
-    QUrl
+    QUrl, QThread
 from PyQt5.QtGui import QPalette, QPainter, QBrush, QColor, QPen, QIcon, QPixmap, QTextDocument, \
     QAbstractTextDocumentLayout, QTransform, QShowEvent, QDesktopServices
 from PyQt5.QtWidgets import QMessageBox, QWidget, QFileDialog, QInputDialog, QItemDelegate, QLineEdit, \
@@ -26,9 +26,44 @@ from PyQt5.QtWidgets import QMessageBox, QWidget, QFileDialog, QInputDialog, QIt
     QProxyStyle, QWidgetItem, QLayout, QSpacerItem, QLabel
 import math
 from common import CancelException
-from thread_fun_dlg import ThreadFunDlg, WorkerThread, CtrlObject
+from thread_fun_dlg import ThreadFunDlg, WorkerThread, WorkerDlgThread, CtrlObject
 
 app_config = None
+
+# Registry of every live background QThread started via WndUtils - both
+# WorkerThread (run_thread) and WorkerDlgThread (run_thread_dialog). Used at
+# application shutdown to cooperatively stop orphan threads (parent=None)
+# that would otherwise be missed by a widget-tree walk, and to keep their
+# sip wrappers strongly referenced past shutdown handling so they are not
+# finalized while the underlying OS thread is still running - which would
+# trigger Qt's "QThread: Destroyed while thread is still running" fatal.
+#
+# Must be a strong container (not WeakSet): PyQt5 does not hold the Python
+# wrapper of a running QThread alive on its own, so a WeakSet entry can
+# disappear as soon as the caller drops its handle (e.g. app_config's
+# delayed_copy worker that is fire-and-forget).
+_live_threads: "List[QThread]" = []
+_live_threads_lock = threading.Lock()
+
+
+def _register_live_thread(thread: QThread):
+    """
+    Add a background thread to the live-thread registry and arrange for it
+    to be removed when it finishes. Safe to call from the main thread only
+    (QThread.finished.connect expects it).
+    """
+    with _live_threads_lock:
+        if thread not in _live_threads:
+            _live_threads.append(thread)
+
+    def _remove():
+        with _live_threads_lock:
+            try:
+                _live_threads.remove(thread)
+            except ValueError:
+                pass
+
+    thread.finished.connect(_remove)
 
 
 def set_app_config(new_app_config):
@@ -227,10 +262,21 @@ class WndUtils:
         def call(worker_fun, worker_fun_args, close_after_finish, buttons, title, text, center_by_window,
                  force_close_dlg_callback, show_window_delay_ms):
 
+            # Refuse to spawn a new background worker once the app has
+            # started shutting down. Without this, a queued handler
+            # dispatched by wait_for_threads' event pump could create a
+            # fresh thread that escapes the already-taken snapshot in
+            # stop_all_threads.
+            if thread_wnd_utils._shutting_down:
+                logging.warning('run_thread_dialog called during shutdown; not starting %s', worker_fun)
+                return None
+
             ui = ThreadFunDlg(worker_fun, worker_fun_args, close_after_finish,
                               buttons=buttons, title=title, text=text, center_by_window=center_by_window,
                               force_close_dlg_callback=force_close_dlg_callback,
                               show_window_delay_ms=show_window_delay_ms)
+            if ui.worker_thread is not None:
+                _register_live_thread(ui.worker_thread)
             ui.wait_for_worker_completion()
             ret = ui.get_result()
             ret_exception = ui.worker_exception
@@ -286,7 +332,17 @@ class WndUtils:
             st = traceback.format_stack()
             logging.error('Running thread from inside another thread. Stack: \n' + ''.join(st))
 
+        # Refuse to spawn a new background worker once the app has started
+        # shutting down. A queued handler dispatched by wait_for_threads'
+        # event pump could otherwise create a fresh thread that escapes
+        # the snapshot taken in stop_all_threads and keep running past
+        # sip cleanup.
+        if thread_wnd_utils._shutting_down:
+            logging.warning('run_thread called during shutdown; not starting %s', worker_fun)
+            return None
+
         thread = WorkerThread(parent=parent, worker_fun=worker_fun, worker_fun_args=worker_fun_args)
+        _register_live_thread(thread)
 
         # in Python 3.5 local variables sometimes are removed before calling on_thread_finished_int
         # so we have to bind that variables with the function ref
@@ -309,6 +365,117 @@ class WndUtils:
 
         return thread_wnd_utils.call_in_main_thread_ext(fun_to_call, skip_if_main_thread_locked,
                                                         callback_if_main_thread_locked, *args, **kwargs)
+
+    @staticmethod
+    def wait_for_threads(threads: List[QThread], timeout_ms: int):
+        """
+        Wait for the given worker threads to finish while pumping the Qt
+        event loop. Needed because a worker may currently be blocked inside
+        call_in_main_thread on a queued fun_call_signal - that signal will
+        only be delivered if the main thread keeps dispatching events while
+        it waits, otherwise it deadlocks against its own workers.
+        """
+        threads = [t for t in threads if t is not None]
+        if not threads:
+            return
+        deadline = time.time() + max(0, timeout_ms) / 1000.0
+        while True:
+            alive = [t for t in threads if t.isRunning()]
+            if not alive:
+                return
+            if time.time() >= deadline:
+                return
+            QApplication.processEvents(QEventLoop.AllEvents, 50)
+            for t in alive:
+                if not t.isRunning():
+                    continue
+                t.wait(50)
+
+    @staticmethod
+    def stop_all_threads(timeout_ms: int = 8000):
+        """
+        Cooperatively stop every live WorkerThread before Qt/sip shutdown.
+
+        Must run while the QApplication event loop is still alive (e.g. from
+        the QApplication.aboutToQuit signal). Without this, worker threads
+        parented to widgets can still be running when sip tears down the
+        QObject tree at interpreter finalization, which makes Qt fatal-abort
+        with "QThread: Destroyed while thread is still running".
+        """
+        # Prevent any further call_in_main_thread invocations from blocking
+        # on the 1h mutex - the main thread is about to stop dispatching
+        # events, so new synchronous calls would deadlock forever.
+        thread_wnd_utils._shutting_down = True
+
+        app = QApplication.instance()
+        if app is None:
+            return
+
+        # Collect every live background thread. The registry (strong refs)
+        # covers both WorkerThread and WorkerDlgThread, including orphan
+        # threads created with parent=None (e.g. app_cache writer,
+        # app_config delayed_copy worker) that a widget-tree walk would
+        # miss. The widget walk is kept as a belt-and-braces source in
+        # case anything ever constructs a worker thread without going
+        # through the WndUtils helpers.
+        threads: List[QThread] = []
+        seen = set()
+        with _live_threads_lock:
+            registered = list(_live_threads)
+        for t in registered:
+            if id(t) not in seen:
+                seen.add(id(t))
+                threads.append(t)
+        for w in app.topLevelWidgets():
+            for t in w.findChildren(WorkerThread):
+                if id(t) not in seen:
+                    seen.add(id(t))
+                    threads.append(t)
+            for t in w.findChildren(WorkerDlgThread):
+                if id(t) not in seen:
+                    seen.add(id(t))
+                    threads.append(t)
+
+        if not threads:
+            return
+
+        # Ask workers to stop via their cooperative flag. Both WorkerThread
+        # and WorkerDlgThread expose a ctrl_obj with a `finish` attribute.
+        for t in threads:
+            try:
+                ctrl = getattr(t, 'ctrl_obj', None)
+                if ctrl is not None:
+                    ctrl.finish = True
+            except Exception:
+                pass
+            try:
+                t.requestInterruption()
+            except Exception:
+                pass
+
+        # Pump events + wait until all finish or timeout. Event pumping is
+        # essential: workers that are currently blocked in mutex.tryLock
+        # inside call_in_main_thread will only be released when the main
+        # thread actually dispatches their queued fun_call_signal.
+        WndUtils.wait_for_threads(threads, timeout_ms)
+
+        # Anything still running after the timeout is a last-resort case.
+        # Detach it from its parent so the Qt parent-destruction cascade
+        # does not touch it - we'd rather leak a thread on exit than crash.
+        # The thread is retained in the module-level _live_threads registry
+        # (or a parent-less entry kept alive by sip through its connected
+        # finished slot), so the Python wrapper will not be finalized while
+        # the underlying OS thread is still running.
+        for t in threads:
+            if t.isRunning():
+                try:
+                    logging.warning(
+                        '%s still running at shutdown; detaching from '
+                        'parent to avoid Qt fatal. worker_fun=%s',
+                        type(t).__name__, getattr(t, 'worker_fun', None))
+                    t.setParent(None)
+                except Exception:
+                    logging.exception('Failed to detach running worker thread at shutdown.')
 
     @staticmethod
     def get_icon_pixmap(ico_file_name: str, rotate=0, force_color_change: str = None) -> QPixmap:
@@ -518,6 +685,14 @@ class ThreadWndUtils(QObject):
         self.fun_call_signal.connect(self.fun_call_signalled)
         self.fun_call_ret_value = None
         self.fun_call_exception = None
+        # Set to True when the application is shutting down. When set,
+        # __call_in_main_thread returns immediately instead of emitting a
+        # signal and blocking on a mutex waiting for the main thread, which
+        # is no longer processing events during finalization. Without this,
+        # worker threads can stay blocked in mutex.tryLock(3600000) at exit
+        # and Qt fatal-aborts with "QThread: Destroyed while thread is still
+        # running" when sip tears down their parent widgets.
+        self._shutting_down = False
 
     def fun_call_signalled(self, fun_to_call, args, kwargs, mutex):
         """
@@ -566,6 +741,19 @@ class ThreadWndUtils(QObject):
         ret = None
         try:
             if threading.current_thread() != threading.main_thread():
+
+                # If the app is shutting down, the main thread is no longer
+                # processing events, so do not try to synchronize with it -
+                # the mutex.tryLock below would block until its 1h timeout,
+                # leaving the worker thread alive past sip cleanup and
+                # triggering the "QThread: Destroyed while thread is still
+                # running" Qt fatal. Raise CancelException so the worker
+                # unwinds through its normal cancel path instead of getting
+                # a surprise None return value that breaks callers which
+                # e.g. tuple-unpack the result (psw_cache.py) or expect an
+                # int (hw_intf_keepkey.py).
+                if self._shutting_down:
+                    raise CancelException()
 
                 # check whether the main thread waits for the lock acquired by the current thread
                 # if so, raise deadlock detected exception

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-version_str = '0.9.40'
+version_str = '0.9.41'


### PR DESCRIPTION
On exit, sip's cleanup_on_exit walked the QObject tree and destroyed worker QThreads that were still running, causing Qt to qFatal/abort. The typical trigger was a worker blocked in call_in_main_thread on the 1h mutex.tryLock while the main thread was already inside Py_FinalizeEx and would no longer dispatch the queued fun_call_signal - permanent deadlock, then crash when sip tore down the parent widget.

- wnd_utils.py: add a _shutting_down flag on ThreadWndUtils. When set, call_in_main_thread short-circuits and returns None instead of emitting a signal and blocking on the mutex. Add WndUtils. wait_for_threads() helper that waits for worker threads while pumping QApplication.processEvents() so workers currently blocked inside call_in_main_thread can still be serviced by the main thread while it waits on them. Add WndUtils.stop_all_threads() which sets the shutdown flag, asks every live WorkerThread to stop, waits with event pumping, and as a last-resort safety net reparents anything still running to None so the Qt parent-destruction cascade does not touch it.
- dash_masternode_tool.py: connect WndUtils.stop_all_threads to QApplication.aboutToQuit so cleanup runs while Qt is still alive, before sip shutdown.
- wallet_dlg.py: WalletDlg.stop_threads now uses wait_for_threads for data/display/update_data_view workers, fixing the main-thread vs. worker self-deadlock and also covering update_data_view_thread_ref which was previously missed.
- app_main_view_wdg.py: AppMainViewWdg.stop_threads gets the same treatment for status/price/net-mns workers, also covering refresh_net_mnasternodes_thred_ref which was previously missed.

NOTE: this patch is vibe-coded via "Claude implements, Codex reviews" approach, I can't guarantee 100% correctness